### PR TITLE
Remove unused framebuffer code

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -70,9 +70,6 @@ typedef void(GL_APIENTRY *PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC)(GL
 
 namespace ovrmobile {
 
-static const int CPU_LEVEL = 2;
-static const int GPU_LEVEL = 3;
-static const int NUM_MULTI_SAMPLES = 4;
 
 inline bool check_bit(uint32_t in, uint32_t bits) {
 	return (in & bits) != 0;

--- a/src/framebuffer.cpp
+++ b/src/framebuffer.cpp
@@ -13,36 +13,23 @@ namespace {
 const int kDefaultBufferCount = 3;
 } // namespace
 
-FrameBuffer::FrameBuffer(const bool useMultiview, const GLenum colorFormat, const int width, const int height, const int multisamples) {
-	auto glRenderbufferStorageMultisampleEXT =
-			(PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC)eglGetProcAddress("glRenderbufferStorageMultisampleEXT");
-	auto glFramebufferTexture2DMultisampleEXT =
-			(PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC)eglGetProcAddress("glFramebufferTexture2DMultisampleEXT");
-
-	auto glFramebufferTextureMultiviewOVR =
-			(PFNGLFRAMEBUFFERTEXTUREMULTIVIEWOVRPROC)eglGetProcAddress("glFramebufferTextureMultiviewOVR");
-	auto glFramebufferTextureMultisampleMultiviewOVR =
-			(PFNGLFRAMEBUFFERTEXTUREMULTISAMPLEMULTIVIEWOVRPROC)eglGetProcAddress("glFramebufferTextureMultisampleMultiviewOVR");
-
+FrameBuffer::FrameBuffer(const GLenum colorFormat, const int width, const int height) {
 	mWidth = width;
 	mHeight = height;
-	mMultisamples = multisamples;
-	mUseMultiview = useMultiview && (glFramebufferTextureMultiviewOVR != NULL);
 
-	mColorTextureSwapChain = vrapi_CreateTextureSwapChain3(mUseMultiview ? VRAPI_TEXTURE_TYPE_2D_ARRAY : VRAPI_TEXTURE_TYPE_2D, colorFormat, width, height, 1, kDefaultBufferCount);
+	// more detail about this initialization code can be found in the Oculus VR SDK in VrSamples/VrCubeWorld_SurfaceView
+	mColorTextureSwapChain = vrapi_CreateTextureSwapChain3(VRAPI_TEXTURE_TYPE_2D, colorFormat, width, height, 1, kDefaultBufferCount);
 	mTextureSwapChainLength = vrapi_GetTextureSwapChainLength(mColorTextureSwapChain);
 	mTextureSwapChainIndex = 0;
-	mDepthBuffers = (GLuint *)malloc(mTextureSwapChainLength * sizeof(GLuint));
-	mFrameBuffers = (GLuint *)malloc(mTextureSwapChainLength * sizeof(GLuint));
 
-	ALOGV("    Framebuffer(...): mUseMultiview = %d; mTextureSwapChainLength=%d; mMultisamples=%d", mUseMultiview, mTextureSwapChainLength, mMultisamples);
+	ALOGV("    Create Framebuffer(...): mTextureSwapChainLength=%d", mTextureSwapChainLength);
 	GL(); // empty GL macro call to catch previous GL errors and not report them on the next GL call in this function
 	
-
 	for (int i = 0; i < mTextureSwapChainLength; i++) {
 		// Create the color buffer texture.
 		const GLuint colorTexture = vrapi_GetTextureSwapChainHandle(mColorTextureSwapChain, i);
-		GLenum colorTextureTarget = mUseMultiview ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+		GLenum colorTextureTarget = GL_TEXTURE_2D;
+
 		GL(glBindTexture(colorTextureTarget, colorTexture));
 		if (OpenGLExtensions::EXT_texture_border_clamp) {
 			GL(glTexParameteri(colorTextureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER));
@@ -58,110 +45,18 @@ FrameBuffer::FrameBuffer(const bool useMultiview, const GLenum colorFormat, cons
 		GL(glTexParameteri(colorTextureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
 		GL(glTexParameteri(colorTextureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
 		GL(glBindTexture(colorTextureTarget, 0));
-
-		if (mUseMultiview) {
-			// Create the depth buffer texture.
-			GL(glGenTextures(1, &mDepthBuffers[i]));
-			GL(glBindTexture(GL_TEXTURE_2D_ARRAY, mDepthBuffers[i]));
-			GL(glTexStorage3D(GL_TEXTURE_2D_ARRAY, 1, GL_DEPTH_COMPONENT24, width, height, 2));
-			GL(glBindTexture(GL_TEXTURE_2D_ARRAY, 0));
-
-			// Create the frame buffer.
-			GL(glGenFramebuffers(1, &mFrameBuffers[i]));
-			GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mFrameBuffers[i]));
-			if (multisamples > 1 && (glFramebufferTextureMultisampleMultiviewOVR != NULL)) {
-				GL(glFramebufferTextureMultisampleMultiviewOVR(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0 /* level */, multisamples /* samples */, 0 /* baseViewIndex */, 2 /* numViews */));
-				GL(glFramebufferTextureMultisampleMultiviewOVR(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTexture, 0 /* level */, multisamples /* samples */, 0 /* baseViewIndex */, 2 /* numViews */));
-			} else {
-				GL(glFramebufferTextureMultiviewOVR(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthBuffers[i], 0 /* level */, 0 /* baseViewIndex */, 2 /* numViews */));
-				GL(glFramebufferTextureMultiviewOVR(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTexture, 0 /* level */, 0 /* baseViewIndex */, 2 /* numViews */));
-			}
-
-			GL(GLenum renderFramebufferStatus = glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER));
-			GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0));
-			if (renderFramebufferStatus != GL_FRAMEBUFFER_COMPLETE) {
-				ALOGE("Incomplete frame buffer object: %s", OpenGLExtensions::GlFrameBufferStatusString(renderFramebufferStatus));
-				return;
-			}
-		} else {
-			if (multisamples > 1 && glRenderbufferStorageMultisampleEXT != NULL && glFramebufferTexture2DMultisampleEXT != NULL) {
-				// Create multisampled depth buffer.
-				GL(glGenRenderbuffers(1, &mDepthBuffers[i]));
-				GL(glBindRenderbuffer(GL_RENDERBUFFER, mDepthBuffers[i]));
-				GL(glRenderbufferStorageMultisampleEXT(GL_RENDERBUFFER, multisamples, GL_DEPTH_COMPONENT24, width, height));
-				GL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
-
-				// Create the frame buffer.
-				// NOTE: glFramebufferTexture2DMultisampleEXT only works with GL_FRAMEBUFFER.
-				GL(glGenFramebuffers(1, &mFrameBuffers[i]));
-				GL(glBindFramebuffer(GL_FRAMEBUFFER, mFrameBuffers[i]));
-				GL(glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture, 0, multisamples));
-				GL(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]));
-				GL(GLenum renderFramebufferStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER));
-				GL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
-				if (renderFramebufferStatus != GL_FRAMEBUFFER_COMPLETE) {
-					ALOGE("Incomplete frame buffer object: %s", OpenGLExtensions::GlFrameBufferStatusString(renderFramebufferStatus));
-					return;
-				}
-			} else {
-				// Create depth buffer.
-				GL(glGenRenderbuffers(1, &mDepthBuffers[i]));
-				GL(glBindRenderbuffer(GL_RENDERBUFFER, mDepthBuffers[i]));
-				GL(glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height));
-				GL(glBindRenderbuffer(GL_RENDERBUFFER, 0));
-
-				// Create the frame buffer.
-				GL(glGenFramebuffers(1, &mFrameBuffers[i]));
-				GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mFrameBuffers[i]));
-				GL(glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, mDepthBuffers[i]));
-				GL(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture, 0));
-				GL(GLenum renderFramebufferStatus = glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER));
-				GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0));
-				if (renderFramebufferStatus != GL_FRAMEBUFFER_COMPLETE) {
-					ALOGE("Incomplete frame buffer object: %s", OpenGLExtensions::GlFrameBufferStatusString(renderFramebufferStatus));
-					return;
-				}
-			}
-		}
-
-		GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mFrameBuffers[i]));
-		GL(glScissor(0, 0, width, height));
-		GL(glViewport(0, 0, width, height));
-		GL(glClear(GL_COLOR_BUFFER_BIT));
-		GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0));
 	}
 }
 
 FrameBuffer::~FrameBuffer() {
-	GL(glDeleteFramebuffers(mTextureSwapChainLength, mFrameBuffers));
-	if (mUseMultiview) {
-		GL(glDeleteTextures(mTextureSwapChainLength, mDepthBuffers));
-	} else {
-		GL(glDeleteRenderbuffers(mTextureSwapChainLength, mDepthBuffers));
-	}
 	vrapi_DestroyTextureSwapChain(mColorTextureSwapChain);
-
-	free(mDepthBuffers);
-	free(mFrameBuffers);
 }
 
-GLuint FrameBuffer::getFrameBufferTexture() {
+GLuint FrameBuffer::get_active_target_texture() {
 	return vrapi_GetTextureSwapChainHandle(mColorTextureSwapChain, mTextureSwapChainIndex);
 }
 
-void FrameBuffer::resolve() {
-	// Discard the depth buffer, so the tiler won't need to write it back out to memory.
-	const GLenum attachments[2] = { GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT };
-	glInvalidateFramebuffer(GL_DRAW_FRAMEBUFFER, sizeof(attachments) / sizeof(attachments[0]), attachments);
-
-	// Flush this frame worth of commands.
-	glFlush();
-
-	GL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0));
-}
-
-void FrameBuffer::advance() {
-	// Advance to the next texture from the set.
+void FrameBuffer::advance_texture_swap_chain() {
 	mTextureSwapChainIndex = (mTextureSwapChainIndex + 1) % mTextureSwapChainLength;
 }
 

--- a/src/framebuffer.h
+++ b/src/framebuffer.h
@@ -9,7 +9,6 @@
 #ifndef OVRMOBILE_FRAMEBUFFER_H
 #define OVRMOBILE_FRAMEBUFFER_H
 
-// Include some standard C stuff
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -18,25 +17,32 @@
 namespace ovrmobile {
 
 class FrameBuffer {
-private:
-	int mWidth;
-	int mHeight;
-	int mMultisamples;
-	int mTextureSwapChainLength;
-	bool mUseMultiview;
-	GLuint *mDepthBuffers;
-	GLuint *mFrameBuffers;
-
 public:
-	int mTextureSwapChainIndex;
-	ovrTextureSwapChain *mColorTextureSwapChain;
 
-	FrameBuffer(const bool useMultiview, const GLenum colorFormat, const int width, const int height, const int multisamples);
+	FrameBuffer(const GLenum colorFormat, const int width, const int height);
 	~FrameBuffer();
 
-	GLuint getFrameBufferTexture();
-	void resolve();
-	void advance();
+	// returns the currently active rendertarget texture from the texture swap chain
+	GLuint get_active_target_texture();
+
+	// Advance to the next rendertarget texture from the texture swap chain
+	void advance_texture_swap_chain();
+
+	int get_texture_swap_chain_index() {
+		return mTextureSwapChainIndex;
+	}
+
+	ovrTextureSwapChain* get_texture_swap_chain() {
+		return mColorTextureSwapChain;
+	}
+
+private:
+
+	int mWidth;
+	int mHeight;
+	int mTextureSwapChainLength;
+	int mTextureSwapChainIndex;
+	ovrTextureSwapChain *mColorTextureSwapChain;
 };
 
 } // namespace ovrmobile


### PR DESCRIPTION
Hi,

this pull request is a proposal for removing some currently unused code to make the plugin easier to maintain. During my last debugging (searching for the controller latency problem) of the godot_oculus_mobile plugin I noticed that the opengl framebuffer setup in framebuffer.cpp is not used and also not needed. It will just use gpu resources for the unused MSAA zbuffers that are created. 
From what I can tell so far godot has an internal setup of the target gl framebuffer for rendering and uses only the target color texture from the swap chain that is created via the VrApi.
This is also the reason why setting MSAA inside the godot_oculus_mobile plugin has no effect.

I also think multiviewsupport will need some changes to the ARVR api; this is the reason why I  removed this setup code from the framebuffer.cpp as it is currently not functional.

The final commit is some small cleanup and renaming of the functions inside framebuffer.h to be more consistent with ovr_mobile_session.h