### PR TITLE
Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,16 @@ func _process(delta):
 	print("GetBoundaryOrientedBoundingBox: ", ovrGuardianSystem.get_boundary_oriented_bounding_box())
 ```
 
+There is also a OvrUtility GDNative script class that exposes some utility functions to configure the 
+compositor and query information:
+```
+onready var ovrUtilities = preload("res://addons/godot_ovrmobile/OvrUtilities.gdns").new()
+
+func do_something():
+  # Query the current IPD; return value is in m
+  print("Current IPD is: %.1fmm" % (ovrUtilities.get_ipd() * 1000.0))
+
+  # set a color multiply (also useful for fade to black)
+  ovrUtilities.set_default_layer_color_scale(Color(1.0, 0.3, 0.4, 1.0));
+```
+

--- a/demo/addons/godot_ovrmobile/OvrUtilities.gdns
+++ b/demo/addons/godot_ovrmobile/OvrUtilities.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot_ovrmobile/godot_ovrmobile.gdnlib" type="GDNativeLibrary" id=1]
+
+[resource]
+resource_name = "OvrUtilities"
+class_name = "OvrUtilities"
+library = ExtResource( 1 )

--- a/src/config/ovr_utilities.cpp
+++ b/src/config/ovr_utilities.cpp
@@ -1,0 +1,61 @@
+#include "config_common.h"
+#include "ovr_utilities.h"
+
+static const char *kClassName = "OvrUtilities";
+
+void register_gdnative_utilities(void *p_handle) {
+    { // register the constructor and destructor of the OvrUtilitites class for use in GDScript
+		godot_instance_create_func create = { NULL, NULL, NULL };
+		create.create_func = &ovr_utilities_constructor;
+
+		godot_instance_destroy_func destroy = { NULL, NULL, NULL };
+		destroy.destroy_func = &ovr_utilities_destructor;
+
+		nativescript_api->godot_nativescript_register_class(p_handle, kClassName, "Reference", create, destroy);
+	}
+
+	{ // register all the functions that we want to expose via the OvrUtilities class in GDScript
+		godot_instance_method method = { NULL, NULL, NULL };
+		godot_method_attributes attributes = { GODOT_METHOD_RPC_MODE_DISABLED };
+
+		method.method = &get_ipd;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_ipd", attributes, method);
+	}
+}
+
+GDCALLINGCONV void *ovr_utilities_constructor(godot_object *p_instance, void *p_method_data) {
+	ovr_config_data_struct *ovr_config_data;
+
+	ovr_config_data = (ovr_config_data_struct *)api->godot_alloc(sizeof(ovr_config_data_struct));
+	if (ovr_config_data != NULL) {
+		ovr_config_data->ovr_mobile_session = ovrmobile::OvrMobileSession::get_singleton_instance();
+	}
+
+	return ovr_config_data;
+}
+
+
+GDCALLINGCONV void ovr_utilities_destructor(godot_object *p_instance, void *p_method_data, void *p_user_data) {
+	if (p_user_data != NULL) {
+		ovr_config_data_struct *ovr_config_data = (ovr_config_data_struct *) p_user_data;
+		if (ovr_config_data->ovr_mobile_session != NULL) {
+			ovr_config_data->ovr_mobile_session = NULL;
+		}
+	}
+}
+
+
+GDCALLINGCONV godot_variant get_ipd(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+        ovrTracking2 head_tracker = ovr_mobile_session->get_head_tracker();
+
+		// here we compute the vector from the origin of the left eye to the right eye by using the transform part of the view matrix
+		float dx = head_tracker.Eye[VRAPI_EYE_RIGHT].ViewMatrix.M[0][3] - head_tracker.Eye[VRAPI_EYE_LEFT].ViewMatrix.M[0][3];
+		float dy = head_tracker.Eye[VRAPI_EYE_RIGHT].ViewMatrix.M[1][3] - head_tracker.Eye[VRAPI_EYE_LEFT].ViewMatrix.M[1][3];
+		float dz = head_tracker.Eye[VRAPI_EYE_RIGHT].ViewMatrix.M[2][3] - head_tracker.Eye[VRAPI_EYE_LEFT].ViewMatrix.M[2][3];
+
+		// the IPD is then just the length of this vector
+        float ipd = sqrtf(dx*dx + dy*dy + dz*dz);
+		api->godot_variant_new_real(&ret, ipd);
+	)	
+}

--- a/src/config/ovr_utilities.cpp
+++ b/src/config/ovr_utilities.cpp
@@ -20,6 +20,9 @@ void register_gdnative_utilities(void *p_handle) {
 
 		method.method = &get_ipd;
 		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_ipd", attributes, method);
+
+		method.method = &set_default_layer_color_scale;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "set_default_layer_color_scale", attributes, method);
 	}
 }
 
@@ -58,4 +61,13 @@ GDCALLINGCONV godot_variant get_ipd(godot_object *p_instance, void *p_method_dat
         float ipd = sqrtf(dx*dx + dy*dy + dz*dz);
 		api->godot_variant_new_real(&ret, ipd);
 	)	
+}
+
+GDCALLINGCONV godot_variant set_default_layer_color_scale(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		godot_color color = api->godot_variant_as_color(p_args[0]);
+		godot_real* pcolor = (godot_real*)&color;
+		ovr_mobile_session->set_default_layer_color_scale(pcolor[0], pcolor[1], pcolor[2], pcolor[3]);
+		api->godot_variant_new_bool(&ret, true);
+	)
 }

--- a/src/config/ovr_utilities.h
+++ b/src/config/ovr_utilities.h
@@ -10,13 +10,16 @@
 extern "C" {
 #endif
 
+// registers the OvrUtilities class and functions to GDNative and should be called from godot_ovrmobile_nativescript_init
 void register_gdnative_utilities(void *p_handle);
 
 GDCALLINGCONV void *ovr_utilities_constructor(godot_object *p_instance, void *p_method_data);
 GDCALLINGCONV void ovr_utilities_destructor(godot_object *p_instance, void *p_method_data, void *p_user_data);
 
+// uses the internal left and right view matrix to compute the IPD. Returns a float in GDScript
 GDCALLINGCONV godot_variant get_ipd(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 
+// Expects a Color parameter in GDScript and sets the color multiplier for the default layer used by the VrAPI compositor
 GDCALLINGCONV godot_variant set_default_layer_color_scale(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 
 

--- a/src/config/ovr_utilities.h
+++ b/src/config/ovr_utilities.h
@@ -16,7 +16,8 @@ GDCALLINGCONV void *ovr_utilities_constructor(godot_object *p_instance, void *p_
 GDCALLINGCONV void ovr_utilities_destructor(godot_object *p_instance, void *p_method_data, void *p_user_data);
 
 GDCALLINGCONV godot_variant get_ipd(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
-// not yet implemented
+
+GDCALLINGCONV godot_variant set_default_layer_color_scale(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 
 
 #ifdef __cplusplus

--- a/src/config/ovr_utilities.h
+++ b/src/config/ovr_utilities.h
@@ -1,0 +1,26 @@
+////////////////////////////////////////////////////////////////////////////////////////////////
+// GDNative module that wraps some utility functions that need the VrApi
+
+#ifndef OVR_UTILITIES_H
+#define OVR_UTILITIES_H
+
+#include "../godot_calls.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void register_gdnative_utilities(void *p_handle);
+
+GDCALLINGCONV void *ovr_utilities_constructor(godot_object *p_instance, void *p_method_data);
+GDCALLINGCONV void ovr_utilities_destructor(godot_object *p_instance, void *p_method_data, void *p_user_data);
+
+GDCALLINGCONV godot_variant get_ipd(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+// not yet implemented
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !OVR_UTILITIES */

--- a/src/godot_ovrmobile.cpp
+++ b/src/godot_ovrmobile.cpp
@@ -13,6 +13,7 @@
 #include "config/ovr_init_config.h"
 #include "config/ovr_performance.h"
 #include "config/ovr_tracking_transform.h"
+#include "config/ovr_utilities.h"
 
 void GDN_EXPORT godot_ovrmobile_gdnative_singleton() {
 	if (arvr_api != NULL) {
@@ -30,4 +31,5 @@ void GDN_EXPORT godot_ovrmobile_nativescript_init(void *p_handle) {
 	register_gdnative_init_config(p_handle);
 	register_gdnative_performance(p_handle);
 	register_gdnative_tracking_transform(p_handle);
+	register_gdnative_utilities(p_handle);
 }

--- a/src/ovr_mobile_session.cpp
+++ b/src/ovr_mobile_session.cpp
@@ -39,6 +39,11 @@ OvrMobileSession::OvrMobileSession() :
 	java.Env = env;
 	env->GetJavaVM(&java.Vm);
 
+	default_layer_color_scale.x = 1.0f;
+	default_layer_color_scale.y = 1.0f;
+	default_layer_color_scale.z = 1.0f;
+	default_layer_color_scale.w = 1.0f;
+
 	ovr_mobile_controller = new OvrMobileController();
 }
 
@@ -122,6 +127,13 @@ godot_transform OvrMobileSession::get_transform_for_eye(godot_int godot_eye, god
 	return ret;
 }
 
+void OvrMobileSession::set_default_layer_color_scale(float r, float g, float b, float a) {
+	default_layer_color_scale.x = r;
+	default_layer_color_scale.y = g;
+	default_layer_color_scale.z = b;
+	default_layer_color_scale.w = a;
+}
+
 void OvrMobileSession::commit_for_eye(godot_int godot_eye) {
 	if (!in_vr_mode()) {
 		return;
@@ -136,6 +148,8 @@ void OvrMobileSession::commit_for_eye(godot_int godot_eye) {
 		layer = vrapi_DefaultLayerProjection2();
 		layer.HeadPose = head_tracker.HeadPose;
 		layer.Header.Flags |= VRAPI_FRAME_LAYER_FLAG_CHROMATIC_ABERRATION_CORRECTION;
+
+		layer.Header.ColorScale = default_layer_color_scale;
 	}
 
 	// Set the layer's texture properties.

--- a/src/ovr_mobile_session.h
+++ b/src/ovr_mobile_session.h
@@ -38,6 +38,8 @@ public:
 	    this->swap_interval = swap_interval;
 	}
 
+	void set_default_layer_color_scale(float r, float g, float b, float a);
+
 	int get_texture_for_eye(godot_int godot_eye);
 
 	godot_transform get_transform_for_eye(godot_int godot_eye, godot_transform *cam_transform);
@@ -72,6 +74,7 @@ public:
 		return &java;
 	}
 
+
 private:
 
 	OvrMobileSession();
@@ -94,6 +97,8 @@ private:
 	unsigned int swap_interval;
 	uint64_t frame_index = 1;
 	double predicted_display_time = 0;
+
+	ovrVector4f default_layer_color_scale;
 
 	ovrJava java;
 	ovrLayerProjection2 layer;

--- a/src/ovr_mobile_session.h
+++ b/src/ovr_mobile_session.h
@@ -66,6 +66,8 @@ public:
 
 	ovrMobile* get_ovr_mobile_context() {return ovr;};
 
+	ovrTracking2 get_head_tracker() {return head_tracker;};
+
 	const ovrJava *get_ovr_java() {
 		return &java;
 	}


### PR DESCRIPTION
This PR contains a proposal to add a OvrUtilities.gdns that has at the moment two functions exposed.

1.: get_ipd(): uses the left and right view matrix to compute and return the current IPD by computing the difference between the left and right eye position.. This can be used to see what IPD was set using the hardware slider on the Oculus Quest (and will also return the IPD of the other oculus mobile headsets)

2: set_default_layer_color_scale(r, g, b, a): this exposes the layer color multiplyer from the VrAPI for the default layer (that is used to display the rendered scene). The main use-case for this is to implement efficient **fade to black**. Using std. post processing for this is too expensive on tiled rendering architectures (see also https://github.com/GodotVR/godot_oculus_mobile/issues/45). For this reason the ColorScale is exposed on each layer.

In the future the OvrUtilities.gdns can also be used to expose other funcitonality to a user like using/configuring the compositing layers.