### PR TITLE
Bump the version of the Oculus mobile SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ oculussig_*
 .idea
 cmake-build-debug
 demo/addons/godot_ovrmobile/libs/
+ovr_sdk_mobile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,14 +63,14 @@ endif (NOT (EXISTS ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}))
 ## The variables below should be updated based on the setup instructions
 ## in the project README.
 
-# Sets the path to the VrApi root directory. Update this variable if the api is in another location.
-set(OVR_ROOT_DIR "${CMAKE_SOURCE_DIR}/ovr_sdk_mobile/1.24.0/VrApi")
+# Sets the path to the VrApi containing directory. Update this variable if the api is in another location.
+set(OVR_ROOT_DIR "${CMAKE_SOURCE_DIR}/ovr_sdk_mobile")
 
 # Location to the Godot headers directory. The default location is "${CMAKE_SOURCE_DIR}/godot_headers"
 set(GODOT_HEADERS_DIR "${CMAKE_SOURCE_DIR}/godot_headers")
 ###############################################################################
 
-set(OVR_HEADERS_DIR "${OVR_ROOT_DIR}/Include" CACHE STRING "")
+set(OVR_HEADERS_DIR "${OVR_ROOT_DIR}/VrApi/Include" CACHE STRING "")
 
 set(GODOT_COMPILE_FLAGS)
 set(GODOT_LINKER_FLAGS)
@@ -100,7 +100,7 @@ else ()
 endif (CMAKE_BUILD_TYPE MATCHES Debug)
 
 # OVR library
-set(VRAPI_LIB_PATH "${OVR_ROOT_DIR}/Libs/Android/${ANDROID_ABI}/${VRAPI_LIB_BUILD_TYPE}/libvrapi.so")
+set(VRAPI_LIB_PATH "${OVR_ROOT_DIR}/VrApi/Libs/Android/${ANDROID_ABI}/${VRAPI_LIB_BUILD_TYPE}/libvrapi.so")
 add_library(vrapi SHARED IMPORTED GLOBAL)
 set_target_properties(vrapi PROPERTIES IMPORTED_LOCATION ${VRAPI_LIB_PATH})
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Oculus Mobile Godot plugin
 
 **Note:**<br> 
-This plugin is in **alpha** state.<br>
-Testing and resolution of remaining issues need to be complete before it's deemed stable and ready for use.<br>
+This plugin is in **beta**.<br>
+Testing needs to be complete before it's deemed stable and ready for use.<br>
 If you'd like to contribute to the testing process, follow the instructions below to setup and use the plugin, 
 and report any issues you encounter. Thanks!<br>
 
@@ -30,7 +30,7 @@ for the **Android SDK & NDK**.
 
 #### Android SDK & NDK
 - Download and setup the [Android SDK](https://developer.android.com/studio/#command-tools).
-  - If using Android Studio, download version **3.4** or higher.
+  - If using Android Studio, download version **3.5** or higher.
   - If using the [command line tools](https://developer.android.com/studio/#command-tools), 
   download revision **26.1.1** or higher. 
   - To ensure you have the latest version, check [SDK Manager](https://developer.android.com/studio/intro/update.html#sdk-manager) for updates.  
@@ -50,11 +50,10 @@ build file if you'd like to provide a different source for the Godot headers.<br
 
 #### Oculus Mobile SDK
 - Download the [latest version](https://developer.oculus.com/downloads/package/oculus-mobile-sdk/)
-(version **1.24.0** or higher) of the Oculus Mobile 
-SDK into a sub-directory of the `ovr_sdk_mobile` directory. It's recommended to use the SDK version as the sub-directory 
-name (e.g: `ovr_sdk_mobile/1.24.0/` for version **1.24.0** of the Oculus Mobile SDK).
-- Update the `OVR_ROOT_DIR` cmake variable in the the `CMakeLists.txt` build file to point to the Oculus Mobile SDK 
-root directory.
+(version **1.25.0** or higher) of the Oculus Mobile SDK into the 
+`ovr_sdk_mobile` directory (create the directory if it doesn't exist).
+- If needed, update the `OVR_ROOT_DIR` cmake variable in the the `CMakeLists.txt` build file to point to the Oculus Mobile SDK 
+containing folder.
 
 Build
 ---------

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,3 +1,3 @@
-1.0.0 (WIP)
-======
-Enable support for Oculus mobile devices to Godot.
+1.0.0-beta
+==========
+Enable support for Oculus mobile devices on Godot.

--- a/ovr_sdk_mobile/.gitignore
+++ b/ovr_sdk_mobile/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Also update the README to simplify the checkout and setup process.

**Note**: The `CMakeLists.txt` build file was updated to remove the Oculus mobile SDK version. This will cause some compilation issues for forks but should simplify the Oculus mobile SDK update process in the future.