### PR TITLE
VrApi properties getter/setter via OvrUtilities.gdns

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ func _process(delta):
 ```
 
 There is also a OvrUtility GDNative script class that exposes some utility functions to configure the 
-compositor and query information:
+compositor or query information:
 ```
 onready var ovrUtilities = preload("res://addons/godot_ovrmobile/OvrUtilities.gdns").new()
 
@@ -109,3 +109,32 @@ func do_something():
   ovrUtilities.set_default_layer_color_scale(Color(1.0, 0.3, 0.4, 1.0));
 ```
 
+In addition to the official API above there is the experimental `OvrVrApiProxy.gdns`
+class that exposes partially the low level property setters/getters from the VrApi.h.
+This API is to be considered temporary and might be removed in future releases of the plugin. If possible it is recommended to use the offical API described above.
+The functions inside the API rely on enum values so there is an convenience class `OvrVrApiTypes.gd` that contains the enum values.
+In the example below you can see a sample usage of the API. For details of the different enum values and query options
+please check the VrApi.h file from the oculus mobile sdk.
+```
+onready var ovr_vr_api_proxy = preload("res://addons/godot_ovrmobile/OvrVrApiProxy.gdns").new();
+onready var ovr_types = preload("res://addons/godot_ovrmobile/OvrVrApiTypes.gd").new();
+
+func test_property_access():
+	print("Testing vrapi access:")
+	print("System property:")
+	print("  vrapi_get_system_property_int(VRAPI_SYS_PROP_DEVICE_TYPE) = ", ovr_vr_api_proxy.vrapi_get_system_property_int(ovr_types.OvrSystemProperty.VRAPI_SYS_PROP_DEVICE_TYPE));
+	print("  vrapi_get_system_property_int(VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH) = ", ovr_vr_api_proxy.vrapi_get_system_property_int(ovr_types.OvrSystemProperty.VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH));
+	
+	print("Property:")
+	print("  vrapi_get_property_int(VRAPI_DEVICE_EMULATION_MODE) = ", ovr_vr_api_proxy.vrapi_get_property_int(ovr_types.OvrProperty.VRAPI_DEVICE_EMULATION_MODE));
+	print("  vrapi_get_property_int(VRAPI_ACTIVE_INPUT_DEVICE_ID) = ", ovr_vr_api_proxy.vrapi_get_property_int(ovr_types.OvrProperty.VRAPI_ACTIVE_INPUT_DEVICE_ID));
+	print("  vrapi_get_property_int(VRAPI_FOVEATION_LEVEL) = ", ovr_vr_api_proxy.vrapi_get_property_int(ovr_types.OvrProperty.VRAPI_FOVEATION_LEVEL));
+	ovr_vr_api_proxy.vrapi_set_property_int(ovr_types.OvrProperty.VRAPI_FOVEATION_LEVEL, 3);
+	print("  vrapi_get_property_int(VRAPI_FOVEATION_LEVEL) = ", ovr_vr_api_proxy.vrapi_get_property_int(ovr_types.OvrProperty.VRAPI_FOVEATION_LEVEL));
+	
+	print("System Status:")
+	print("  vrapi_get_system_status_int(VRAPI_SYS_STATUS_MOUNTED) = ", ovr_vr_api_proxy.vrapi_get_system_status_int(ovr_types.OvrSystemStatus.VRAPI_SYS_STATUS_MOUNTED));
+	print("  vrapi_get_system_status_int(VRAPI_SYS_STATUS_RENDER_LATENCY_MILLISECONDS) = ", ovr_vr_api_proxy.vrapi_get_system_status_int(ovr_types.OvrSystemStatus.VRAPI_SYS_STATUS_RENDER_LATENCY_MILLISECONDS));
+	print("  vrapi_get_system_status_int(VRAPI_SYS_STATUS_FRONT_BUFFER_SRGB) = ", ovr_vr_api_proxy.vrapi_get_system_status_int(ovr_types.OvrSystemStatus.VRAPI_SYS_STATUS_FRONT_BUFFER_SRGB));
+	
+```

--- a/demo/addons/godot_ovrmobile/OvrVrApiProxy.gdns
+++ b/demo/addons/godot_ovrmobile/OvrVrApiProxy.gdns
@@ -1,0 +1,8 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot_ovrmobile/godot_ovrmobile.gdnlib" type="GDNativeLibrary" id=1]
+
+[resource]
+resource_name = "OvrVrApiProxy"
+class_name = "OvrVrApiProxy"
+library = ExtResource( 1 )

--- a/demo/addons/godot_ovrmobile/OvrVrApiTypes.gd
+++ b/demo/addons/godot_ovrmobile/OvrVrApiTypes.gd
@@ -1,0 +1,210 @@
+# these enums are taken from VrApi_Types.h version 1.26.0 for gdscript use; 
+# for further documentation check the VrApi_Types.h file in the oculus mobile sdk
+
+enum OvrDeviceType {
+	VRAPI_DEVICE_TYPE_GEARVR_START			= 0,
+
+	VRAPI_DEVICE_TYPE_NOTE4					= 0, #VRAPI_DEVICE_TYPE_GEARVR_START,
+	VRAPI_DEVICE_TYPE_NOTE5					= 1,
+	VRAPI_DEVICE_TYPE_S6					= 2,
+	VRAPI_DEVICE_TYPE_S7					= 3,
+	VRAPI_DEVICE_TYPE_NOTE7					= 4,			#< No longer supported.
+	VRAPI_DEVICE_TYPE_S8					= 5,
+	VRAPI_DEVICE_TYPE_NOTE8					= 6,
+	VRAPI_DEVICE_TYPE_NOTE7_FE				= 7,			#< Fan Edition
+	VRAPI_DEVICE_TYPE_A8					= 8,
+	VRAPI_DEVICE_TYPE_A8_PLUS				= 9,
+	VRAPI_DEVICE_TYPE_S9					= 10,
+	VRAPI_DEVICE_TYPE_S9_PLUS				= 11,
+	VRAPI_DEVICE_TYPE_A8_STAR 				= 12,
+	VRAPI_DEVICE_TYPE_NOTE9           		= 13,
+	VRAPI_DEVICE_TYPE_A9_2018				= 14,
+	VRAPI_DEVICE_TYPE_S10					= 15,
+	VRAPI_DEVICE_TYPE_GEARVR_END			= 63,
+
+	# Standalone Devices
+	VRAPI_DEVICE_TYPE_OCULUSGO_START		= 64,
+	VRAPI_DEVICE_TYPE_OCULUSGO				= 64, #VRAPI_DEVICE_TYPE_OCULUSGO_START,
+	VRAPI_DEVICE_TYPE_MIVR_STANDALONE		= 64 + 1, #VRAPI_DEVICE_TYPE_OCULUSGO_START + 1,	#< China-only SKU
+	VRAPI_DEVICE_TYPE_OCULUSGO_END			= 127,
+
+	VRAPI_DEVICE_TYPE_OCULUSQUEST_START		= 256,
+	VRAPI_DEVICE_TYPE_OCULUSQUEST			= 256 + 3, #VRAPI_DEVICE_TYPE_OCULUSQUEST_START + 3,
+	VRAPI_DEVICE_TYPE_OCULUSQUEST_END		= 319,
+
+	VRAPI_DEVICE_TYPE_UNKNOWN				= -1,
+}
+
+##/ A headset, which typically includes optics and tracking hardware, but not necessarily the device itself.
+enum OvrHeadsetType {
+	VRAPI_HEADSET_TYPE_R320					= 0,			#< Note4 Innovator
+	VRAPI_HEADSET_TYPE_R321					= 1,			#< S6 Innovator
+	VRAPI_HEADSET_TYPE_R322					= 2,			#< Commercial 1
+	VRAPI_HEADSET_TYPE_R323					= 3,			#< Commercial 2 (USB Type C)
+	VRAPI_HEADSET_TYPE_R324					= 4,			#< Commercial 3 (USB Type C)
+	VRAPI_HEADSET_TYPE_R325					= 5,			#< Commercial 4 2017 (USB Type C)
+
+	# Standalone Headsets
+	VRAPI_HEADSET_TYPE_OCULUSGO				= 64,			#< Oculus Go
+	VRAPI_HEADSET_TYPE_MIVR_STANDALONE		= 65,			#< China-only SKU
+
+	VRAPI_HEADSET_TYPE_OCULUSQUEST			= 256,
+
+
+	VRAPI_HEADSET_TYPE_UNKNOWN				= -1,
+}
+
+##/ A geographic region authorized for certain hardware and content.
+enum OvrDeviceRegion {
+	VRAPI_DEVICE_REGION_UNSPECIFIED	= 0,
+	VRAPI_DEVICE_REGION_JAPAN		= 1,
+	VRAPI_DEVICE_REGION_CHINA		= 2,
+}
+
+enum OvrDeviceEmulationMode {
+	VRAPI_DEVICE_EMULATION_MODE_NONE		= 0,
+	VRAPI_DEVICE_EMULATION_MODE_GO_ON_QUEST	= 1,
+}
+
+
+
+enum OvrProperty {
+	VRAPI_FOVEATION_LEVEL 								= 15, #< Used by apps that want to control swapchain foveation levels.
+	VRAPI_REORIENT_HMD_ON_CONTROLLER_RECENTER 			= 17, #< Used to determine if a controller recenter should also reorient the headset.
+	VRAPI_LATCH_BACK_BUTTON_ENTIRE_FRAME 				= 18, #< Used to determine if the 'short press' back button should lasts an entire frame.
+	VRAPI_BLOCK_REMOTE_BUTTONS_WHEN_NOT_EMULATING_HMT 	= 19, #< Used to not send the remote back button java events to the apps.
+	VRAPI_ACTIVE_INPUT_DEVICE_ID 						= 24, #< Used by apps to query which input device is most 'active' or primary, a# -1 means no active input device
+	VRAPI_DEVICE_EMULATION_MODE 						= 29, #< Used by apps to determine if they are running in an emulation mode. Is a OvrDeviceEmulationMode value
+}
+
+enum OvrHandedness {
+	VRAPI_HAND_UNKNOWN	= 0,
+	VRAPI_HAND_LEFT		= 1,
+	VRAPI_HAND_RIGHT	= 2
+}
+
+enum OvrSystemProperty {
+	VRAPI_SYS_PROP_DEVICE_TYPE								= 0,
+	VRAPI_SYS_PROP_MAX_FULLSPEED_FRAMEBUFFER_SAMPLES		= 1,
+	# Physical width and height of the display in pixels.
+	VRAPI_SYS_PROP_DISPLAY_PIXELS_WIDE						= 2,
+	VRAPI_SYS_PROP_DISPLAY_PIXELS_HIGH						= 3,
+	# Returns the refresh rate of the display in cycles per second.
+	VRAPI_SYS_PROP_DISPLAY_REFRESH_RATE						= 4,
+	# With a display resolution of 2560x1440, the pixels at the center
+	# of each eye cover about 0.06 degrees of visual arc. To wrap a
+	# full 360 degrees, about 6000 pixels would be needed and about one
+	# quarter of that would be needed for ~90 degrees FOV. As such, Eye
+	# images with a resolution of 1536x1536 result in a good 1:1 mapping
+	# in the center, but they need mip-maps for off center pixels. To
+	# avoid the need for mip-maps and for significantly improved rendering
+	# performance this currently returns a conservative 1024x1024.
+	VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH				= 5,
+	VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_HEIGHT				= 6,
+	# This is a product of the lens distortion and the screen size,
+	# but there is no truly correct answer.
+	# There is a tradeoff in resolution and coverage.
+	# Too small of an FOV will leave unrendered pixels visible, but too
+	# large wastes resolution or fill rate.  It is unreasonable to
+	# increase it until the corners are completely covered, but we do
+	# want most of the outside edges completely covered.
+	# Applications might choose to render a larger FOV when angular
+	# acceleration is high to reduce black pull in at the edges by
+	# the time warp.
+	# Currently symmetric 90.0 degrees.
+	VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_X				= 7,
+	VRAPI_SYS_PROP_SUGGESTED_EYE_FOV_DEGREES_Y				= 8,
+	# Path to the external SD card. On Android-M, this path is dynamic and can
+	# only be determined once the SD card is mounted. Returns an empty string if
+	# device does not support an ext sdcard or if running Android-M and the SD card
+	# is not mounted.
+	VRAPI_SYS_PROP_EXT_SDCARD_PATH							= 9,
+	VRAPI_SYS_PROP_DEVICE_REGION							= 10,
+	# Video decoder limit for the device.
+	VRAPI_SYS_PROP_VIDEO_DECODER_LIMIT						= 11,
+	VRAPI_SYS_PROP_HEADSET_TYPE								= 12,
+
+	# enum 13 used to be VRAPI_SYS_PROP_BACK_BUTTON_SHORTPRESS_TIME
+	# enum 14 used to be VRAPI_SYS_PROP_BACK_BUTTON_DOUBLETAP_TIME
+
+	# Returns an OvrHandedness enum indicating left or right hand.
+	VRAPI_SYS_PROP_DOMINANT_HAND							= 15,
+
+	# Returns the number of display refresh rates supported by the system.
+	VRAPI_SYS_PROP_NUM_SUPPORTED_DISPLAY_REFRESH_RATES		= 64,
+	# Returns an array of the supported display refresh rates.
+	VRAPI_SYS_PROP_SUPPORTED_DISPLAY_REFRESH_RATES			= 65,
+
+	# Returns the number of swapchain texture formats supported by the system.
+	VRAPI_SYS_PROP_NUM_SUPPORTED_SWAPCHAIN_FORMATS			= 66,
+	# Returns an array of the supported swapchain formats.
+	# Formats are platform specific. For GLES, this is an array of
+	# GL internal formats.
+	VRAPI_SYS_PROP_SUPPORTED_SWAPCHAIN_FORMATS				= 67,
+
+	# Returns VRAPI_TRUE if Multiview rendering support is available for this system,
+	# otherwise VRAPI_FALSE.
+	VRAPI_SYS_PROP_MULTIVIEW_AVAILABLE						= 128,
+
+	# Returns VRAPI_TRUE if submission of SRGB Layers is supported for this system,
+	# otherwise VRAPI_FALSE.
+	VRAPI_SYS_PROP_SRGB_LAYER_SOURCE_AVAILABLE				= 129,
+
+	# Returns VRAPI_TRUE if on-chip foveated rendering of swapchains is supported
+	# for this system, otherwise VRAPI_FALSE.
+	VRAPI_SYS_PROP_FOVEATION_AVAILABLE						= 130,
+}
+
+enum OvrSystemStatus {
+	VRAPI_SYS_STATUS_DOCKED							= 0,	#< Device is docked.
+	VRAPI_SYS_STATUS_MOUNTED						= 1,	#< Device is mounted.
+	VRAPI_SYS_STATUS_THROTTLED						= 2,	#< Device is in powersave mode.
+	# enum  3 used to be VRAPI_SYS_STATUS_THROTTLED2.
+	# enum  4 used to be VRAPI_SYS_STATUS_THROTTLED_WARNING_LEVEL.
+	VRAPI_SYS_STATUS_RENDER_LATENCY_MILLISECONDS	= 5,	#< Average time between render tracking sample and scanout.
+	VRAPI_SYS_STATUS_TIMEWARP_LATENCY_MILLISECONDS	= 6,	#< Average time between timewarp tracking sample and scanout.
+	VRAPI_SYS_STATUS_SCANOUT_LATENCY_MILLISECONDS	= 7,	#< Average time between Vsync and scanout.
+	VRAPI_SYS_STATUS_APP_FRAMES_PER_SECOND			= 8,	#< Number of frames per second delivered through vrapi_SubmitFrame.
+	VRAPI_SYS_STATUS_SCREEN_TEARS_PER_SECOND		= 9,	#< Number of screen tears per second (per eye).
+	VRAPI_SYS_STATUS_EARLY_FRAMES_PER_SECOND		= 10,	#< Number of frames per second delivered a whole display refresh early.
+	VRAPI_SYS_STATUS_STALE_FRAMES_PER_SECOND		= 11,	#< Number of frames per second delivered late.
+	# enum 12 used to be VRAPI_SYS_STATUS_HEADPHONES_PLUGGED_IN
+	VRAPI_SYS_STATUS_RECENTER_COUNT					= 13,	#< Returns the current HMD recenter count. Defaults to 0.
+	VRAPI_SYS_STATUS_SYSTEM_UX_ACTIVE				= 14,	#< Returns VRAPI_TRUE if a system UX layer is active
+	VRAPI_SYS_STATUS_USER_RECENTER_COUNT			= 15,	#< Returns the current HMD recenter count for user initiated recenters only. Defaults to 0.
+
+	VRAPI_SYS_STATUS_FRONT_BUFFER_PROTECTED			= 128,	#< VRAPI_TRUE if the front buffer is allocated in TrustZone memory.
+	VRAPI_SYS_STATUS_FRONT_BUFFER_565				= 129,	#< VRAPI_TRUE if the front buffer is 16-bit 5:6:5
+	VRAPI_SYS_STATUS_FRONT_BUFFER_SRGB				= 130,	#< VRAPI_TRUE if the front buffer uses the sRGB color space.
+}
+
+
+enum OvrTrackingTransform {
+	VRAPI_TRACKING_TRANSFORM_IDENTITY					= 0,
+	VRAPI_TRACKING_TRANSFORM_CURRENT					= 1,
+	VRAPI_TRACKING_TRANSFORM_SYSTEM_CENTER_EYE_LEVEL	= 2,
+	VRAPI_TRACKING_TRANSFORM_SYSTEM_CENTER_FLOOR_LEVEL	= 3,
+}
+
+enum OvrTrackingSpace {
+	VRAPI_TRACKING_SPACE_LOCAL				= 0,	# Eye level origin - controlled by system recentering
+	VRAPI_TRACKING_SPACE_LOCAL_FLOOR		= 1,	# Floor level origin - controlled by system recentering
+	VRAPI_TRACKING_SPACE_LOCAL_TILTED		= 2,	# Tilted pose for "bed mode" - controlled by system recentering
+	VRAPI_TRACKING_SPACE_STAGE				= 3,	# Floor level origin - controlled by Guardian setup
+	VRAPI_TRACKING_SPACE_LOCAL_FIXED_YAW	= 7,	# Position of local space, but yaw stays constant
+}
+
+enum OvrTrackedDeviceTypeId {
+	VRAPI_TRACKED_DEVICE_NONE 			= -1,
+	VRAPI_TRACKED_DEVICE_HMD 			= 0,	#< Headset
+	VRAPI_TRACKED_DEVICE_HAND_LEFT 		= 1,	#< Left controller
+	VRAPI_TRACKED_DEVICE_HAND_RIGHT 	= 2,	#< Right controller
+	VRAPI_NUM_TRACKED_DEVICES			= 3,
+}
+
+
+enum OvrExtraLatencyMode {
+	VRAPI_EXTRA_LATENCY_MODE_OFF		= 0,
+	VRAPI_EXTRA_LATENCY_MODE_ON			= 1,
+	VRAPI_EXTRA_LATENCY_MODE_DYNAMIC	= 2
+}

--- a/src/config/ovr_vr_api_proxy.cpp
+++ b/src/config/ovr_vr_api_proxy.cpp
@@ -1,0 +1,126 @@
+#include "config_common.h"
+#include "ovr_vr_api_proxy.h"
+
+static const char *kClassName = "OvrVrApiProxy";
+
+void register_gdnative_vr_api_proxy(void *p_handle) {
+    { // register the constructor and destructor of the OvrVrApiProxy class for use in GDScript
+		godot_instance_create_func create = { NULL, NULL, NULL };
+		create.create_func = &ovr_vr_api_proxy_constructor;
+
+		godot_instance_destroy_func destroy = { NULL, NULL, NULL };
+		destroy.destroy_func = &ovr_vr_api_proxy_destructor;
+
+		nativescript_api->godot_nativescript_register_class(p_handle, kClassName, "Reference", create, destroy);
+	}
+
+	{ // register all the functions that we want to expose via the OvrVrApiProxy class in GDScript
+		godot_instance_method method = { NULL, NULL, NULL };
+		godot_method_attributes attributes = { GODOT_METHOD_RPC_MODE_DISABLED };
+
+		method.method = &vrapi_set_property_int;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_set_property_int", attributes, method);
+		method.method = &vrapi_set_property_float;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_set_property_float", attributes, method);
+		method.method = &vrapi_get_property_int;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_get_property_int", attributes, method);
+		
+		method.method = &vrapi_get_system_property_int;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_get_system_property_int", attributes, method);
+		method.method = &vrapi_get_system_property_float;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_get_system_property_float", attributes, method);
+		
+		method.method = &vrapi_get_system_status_int;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_get_system_status_int", attributes, method);
+		method.method = &vrapi_get_system_status_float;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "vrapi_get_system_status_float", attributes, method);
+	}
+}
+
+GDCALLINGCONV void *ovr_vr_api_proxy_constructor(godot_object *p_instance, void *p_method_data) {
+	ovr_config_data_struct *ovr_config_data;
+
+	ovr_config_data = (ovr_config_data_struct *)api->godot_alloc(sizeof(ovr_config_data_struct));
+	if (ovr_config_data != NULL) {
+		ovr_config_data->ovr_mobile_session = ovrmobile::OvrMobileSession::get_singleton_instance();
+	}
+
+	return ovr_config_data;
+}
+
+
+GDCALLINGCONV void ovr_vr_api_proxy_destructor(godot_object *p_instance, void *p_method_data, void *p_user_data) {
+	if (p_user_data != NULL) {
+		ovr_config_data_struct *ovr_config_data = (ovr_config_data_struct *) p_user_data;
+		if (ovr_config_data->ovr_mobile_session != NULL) {
+			ovr_config_data->ovr_mobile_session = NULL;
+		}
+	}
+}
+
+
+GDCALLINGCONV godot_variant vrapi_set_property_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrProperty propType = (ovrProperty)api->godot_variant_as_int(p_args[0]);
+	    int propValue = api->godot_variant_as_int(p_args[1]);
+	    vrapi_SetPropertyInt(ovr_java, propType, propValue);
+	    api->godot_variant_new_bool(&ret, true); // there seams to be no error handling for the VrApi SetProperty function so we just return true here
+	)
+}
+
+GDCALLINGCONV godot_variant vrapi_set_property_float(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrProperty propType = (ovrProperty)api->godot_variant_as_int(p_args[0]);
+	    godot_real propValue = api->godot_variant_as_real(p_args[1]);
+	    vrapi_SetPropertyFloat(ovr_java, propType, propValue);
+	    api->godot_variant_new_bool(&ret, true); // there seams to be no error handling for the VrApi SetProperty function so we just return true here
+	)
+}
+
+GDCALLINGCONV godot_variant vrapi_get_property_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrProperty propType = (ovrProperty)api->godot_variant_as_int(p_args[0]);
+		int prop = 0;
+		bool valid = vrapi_GetPropertyInt(ovr_java, propType, &prop);
+		if (valid) {
+			api->godot_variant_new_int(&ret, prop);
+		} else {
+			api->godot_variant_new_nil(&ret); // return nil when the query was invalid
+		}
+	)
+}
+
+
+
+GDCALLINGCONV godot_variant vrapi_get_system_property_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrSystemProperty propType = (ovrSystemProperty)api->godot_variant_as_int(p_args[0]);
+		int prop = vrapi_GetSystemPropertyInt(ovr_java, propType);
+		api->godot_variant_new_int(&ret, prop);
+	)
+}
+
+GDCALLINGCONV godot_variant vrapi_get_system_property_float(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrSystemProperty propType = (ovrSystemProperty)api->godot_variant_as_int(p_args[0]);
+		godot_real prop = vrapi_GetSystemPropertyFloat(ovr_java, propType);
+		api->godot_variant_new_real(&ret, prop);
+	)
+}
+
+
+GDCALLINGCONV godot_variant vrapi_get_system_status_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrSystemStatus statusType = (ovrSystemStatus)api->godot_variant_as_int(p_args[0]);
+		int status = vrapi_GetSystemStatusInt(ovr_java, statusType);
+		api->godot_variant_new_int(&ret, status);
+	)
+}
+
+GDCALLINGCONV godot_variant vrapi_get_system_status_float(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		ovrSystemStatus statusType = (ovrSystemStatus)api->godot_variant_as_int(p_args[0]);
+		godot_real status = vrapi_GetSystemStatusFloat(ovr_java, statusType);
+		api->godot_variant_new_real(&ret, status);
+	)
+}

--- a/src/config/ovr_vr_api_proxy.h
+++ b/src/config/ovr_vr_api_proxy.h
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////////////////////////
+// This GDNative module is to be considered temporary and experimental. It exposes part
+// of the VrApi.h directly to gdscript and is for low level access of VrApi features.
+// It might get replaced by dedicated functions in the future.
+
+#ifndef OVR_VR_API_PROXY_H
+#define OVR_VR_API_PROXY_H
+
+#include "../godot_calls.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// registers the OvrVrApiProxy class and functions to GDNative and should be called from godot_ovrmobile_nativescript_init
+void register_gdnative_vr_api_proxy(void *p_handle);
+
+GDCALLINGCONV void *ovr_vr_api_proxy_constructor(godot_object *p_instance, void *p_method_data);
+GDCALLINGCONV void ovr_vr_api_proxy_destructor(godot_object *p_instance, void *p_method_data, void *p_user_data);
+
+// OVR_VRAPI_EXPORT void vrapi_SetPropertyInt( const ovrJava * java, const ovrProperty propType, const int intVal );
+GDCALLINGCONV godot_variant vrapi_set_property_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+// OVR_VRAPI_EXPORT void vrapi_SetPropertyFloat( const ovrJava * java, const ovrProperty propType, const float floatVal );
+GDCALLINGCONV godot_variant vrapi_set_property_float(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+// OVR_VRAPI_EXPORT bool vrapi_GetPropertyInt( const ovrJava * java, const ovrProperty propType, int * intVal );
+GDCALLINGCONV godot_variant vrapi_get_property_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+
+// OVR_VRAPI_EXPORT int vrapi_GetSystemPropertyInt( const ovrJava * java, const ovrSystemProperty propType );
+GDCALLINGCONV godot_variant vrapi_get_system_property_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+// OVR_VRAPI_EXPORT float vrapi_GetSystemPropertyFloat( const ovrJava * java, const ovrSystemProperty propType );
+GDCALLINGCONV godot_variant vrapi_get_system_property_float(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+// OVR_VRAPI_EXPORT int vrapi_GetSystemPropertyFloatArray( const ovrJava * java, const ovrSystemProperty propType, float * values, int numArrayValues );
+// not yet implemented
+
+// OVR_VRAPI_EXPORT int vrapi_GetSystemPropertyInt64Array( const ovrJava * java, const ovrSystemProperty propType, int64_t * values, int numArrayValues );
+// not yet implemented
+
+// OVR_VRAPI_EXPORT const char * vrapi_GetSystemPropertyString( const ovrJava * java, const ovrSystemProperty propType );
+// not yet implemented
+
+
+// OVR_VRAPI_EXPORT int vrapi_GetSystemStatusInt( const ovrJava * java, const ovrSystemStatus statusType );
+GDCALLINGCONV godot_variant vrapi_get_system_status_int(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+// OVR_VRAPI_EXPORT float vrapi_GetSystemStatusFloat( const ovrJava * java, const ovrSystemStatus statusType );
+GDCALLINGCONV godot_variant vrapi_get_system_status_float(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !OVR_VRAPIPROXY */

--- a/src/godot_ovrmobile.cpp
+++ b/src/godot_ovrmobile.cpp
@@ -15,6 +15,9 @@
 #include "config/ovr_tracking_transform.h"
 #include "config/ovr_utilities.h"
 
+// experimental low-level VrApi access
+#include "config/ovr_vr_api_proxy.h"
+
 void GDN_EXPORT godot_ovrmobile_gdnative_singleton() {
 	if (arvr_api != NULL) {
 		arvr_api->godot_arvr_register_interface(&interface_struct);
@@ -32,4 +35,5 @@ void GDN_EXPORT godot_ovrmobile_nativescript_init(void *p_handle) {
 	register_gdnative_performance(p_handle);
 	register_gdnative_tracking_transform(p_handle);
 	register_gdnative_utilities(p_handle);
+	register_gdnative_vr_api_proxy(p_handle);
 }

--- a/src/ovr_mobile_session.cpp
+++ b/src/ovr_mobile_session.cpp
@@ -81,8 +81,9 @@ bool OvrMobileSession::initialize() {
 	height = static_cast<int>(render_target_size_multiplier *
 							  vrapi_GetSystemPropertyInt(&java,
 														 VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_HEIGHT));
-	ALOGV(" render target size multiplier: %f", render_target_size_multiplier);
-	ALOGV(" vrapi render target size: w %i / h %i", width, height);
+	ALOGV(" vrapi version string: '%s'", vrapi_GetVersionString());
+	ALOGV("   render target size multiplier: %f", render_target_size_multiplier);
+	ALOGV("   vrapi render target size: w %i / h %i", width, height);
 
 	// Create Frame buffers for each eye
 	for (auto &eye_frame_buffer : frame_buffers) {


### PR DESCRIPTION
Hi, 

this is a proposal to expose some of the VrApi.h property getters/setters (like `vrapi_set_property_int(...)` or `vrapi_get_system_status_int(...)` generically in the OvrUtilities.gdns class to gdscript. They are very useful to have when building applications that need to make decisions based on the headset type or status (for example device type or region).
For easier use I also added a script `addons/godot_ovrmobile/OvrVrApi_Types.gd` that contains the property enum definitions from `VrApi_Types.h` for use in gdscript.

Here is an example how this api can be used in gdscript:
```
onready var ovr_utilities = preload("res://addons/godot_ovrmobile/OvrUtilities.gdns").new();
onready var ovr_types = preload("res://addons/godot_ovrmobile/OvrVrApi_Types.gd").new();

func test_property_access():
	print("System property:")
	print("  vrapi_get_system_property_int(VRAPI_SYS_PROP_DEVICE_TYPE) = ", ovr_utilities.vrapi_get_system_property_int(ovr_types.ovrSystemProperty.VRAPI_SYS_PROP_DEVICE_TYPE));
	print("  vrapi_get_system_property_int(VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH) = ", ovr_utilities.vrapi_get_system_property_int(ovr_types.ovrSystemProperty.VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH));
	print("  vrapi_get_system_property_int(VRAPI_SYS_PROP_DOMINANT_HAND) = ", ovr_utilities.vrapi_get_system_property_int(ovr_types.ovrSystemProperty.VRAPI_SYS_PROP_DOMINANT_HAND));
		
	print("Property:")
	print("  vrapi_get_property_int(VRAPI_DEVICE_EMULATION_MODE) = ", ovr_utilities.vrapi_get_property_int(ovr_types.ovrProperty.VRAPI_DEVICE_EMULATION_MODE));
	print("  vrapi_get_property_int(VRAPI_FOVEATION_LEVEL) = ", ovr_utilities.vrapi_get_property_int(ovr_types.ovrProperty.VRAPI_FOVEATION_LEVEL));
	ovr_utilities.vrapi_set_property_int(ovr_types.ovrProperty.VRAPI_FOVEATION_LEVEL, 3);
	print("  vrapi_get_property_int(VRAPI_FOVEATION_LEVEL) = ", ovr_utilities.vrapi_get_property_int(ovr_types.ovrProperty.VRAPI_FOVEATION_LEVEL));
	print("  vrapi_get_property_int(VRAPI_ACTIVE_INPUT_DEVICE_ID) = ", ovr_utilities.vrapi_get_property_int(ovr_types.ovrProperty.VRAPI_ACTIVE_INPUT_DEVICE_ID));
		
	print("System Status:")
	print("  vrapi_get_system_status_int(VRAPI_SYS_STATUS_MOUNTED) = ", ovr_utilities.vrapi_get_system_status_int(ovr_types.ovrSystemStatus.VRAPI_SYS_STATUS_MOUNTED));
	print("  vrapi_get_system_status_int(VRAPI_SYS_STATUS_RENDER_LATENCY_MILLISECONDS) = ", ovr_utilities.vrapi_get_system_status_int(ovr_types.ovrSystemStatus.VRAPI_SYS_STATUS_RENDER_LATENCY_MILLISECONDS));
	print("  vrapi_get_system_status_int(VRAPI_SYS_STATUS_FRONT_BUFFER_SRGB) = ", ovr_utilities.vrapi_get_system_status_int(ovr_types.ovrSystemStatus.VRAPI_SYS_STATUS_FRONT_BUFFER_SRGB));
```

I added this example also to the README.md
