### PR TITLE
GDScript API for velocity/acceleration access

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,22 @@ func do_something():
 
   # set a color multiply (also useful for fade to black)
   ovrUtilities.set_default_layer_color_scale(Color(1.0, 0.3, 0.4, 1.0));
+
+  # query controller acceleration/velocities; return value is Vector3
+  print(ovrUtilities.get_controller_angular_velocity(1)); # parameter is the controller_id (either 1 or 2)
+  print(ovrUtilities.get_controller_linear_velocity(1));
+  print(ovrUtilities.get_controller_angular_acceleration(1));
+  print(ovrUtilities.get_controller_linear_acceleration(1));
+
+  # the same is available for the head:
+  print(ovrUtilities.get_head_angular_velocity());
+  print(ovrUtilities.get_head_linear_velocity());
+  print(ovrUtilities.get_head_angular_acceleration());
+  print(ovrUtilities.get_head_linear_acceleration());
 ```
 
+Advanced GDScript Oculus VrApi access
+------------
 In addition to the official API above there is the experimental `OvrVrApiProxy.gdns`
 class that exposes partially the low level property setters/getters from the VrApi.h.
 This API is to be considered temporary and might be removed in future releases of the plugin. If possible it is recommended to use the offical API described above.

--- a/src/config/ovr_utilities.cpp
+++ b/src/config/ovr_utilities.cpp
@@ -1,5 +1,6 @@
 #include "config_common.h"
 #include "ovr_utilities.h"
+#include "ovr_mobile_controller.h"
 
 static const char *kClassName = "OvrUtilities";
 
@@ -23,6 +24,25 @@ void register_gdnative_utilities(void *p_handle) {
 
 		method.method = &set_default_layer_color_scale;
 		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "set_default_layer_color_scale", attributes, method);
+
+		method.method = &get_controller_angular_velocity;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_controller_angular_velocity", attributes, method);
+		method.method = &get_controller_linear_velocity;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_controller_linear_velocity", attributes, method);
+		method.method = &get_controller_angular_acceleration;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_controller_angular_acceleration", attributes, method);
+		method.method = &get_controller_linear_acceleration;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_controller_linear_acceleration", attributes, method);
+
+		method.method = &get_head_angular_velocity;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_head_angular_velocity", attributes, method);
+		method.method = &get_head_linear_velocity;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_head_linear_velocity", attributes, method);
+		method.method = &get_head_angular_acceleration;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_head_angular_acceleration", attributes, method);
+		method.method = &get_head_linear_acceleration;
+		nativescript_api->godot_nativescript_register_method(p_handle, kClassName, "get_head_linear_acceleration", attributes, method);
+
 	}
 }
 
@@ -69,5 +89,119 @@ GDCALLINGCONV godot_variant set_default_layer_color_scale(godot_object *p_instan
 		godot_real* pcolor = (godot_real*)&color;
 		ovr_mobile_session->set_default_layer_color_scale(pcolor[0], pcolor[1], pcolor[2], pcolor[3]);
 		api->godot_variant_new_bool(&ret, true);
+	)
+}
+
+
+GDCALLINGCONV godot_variant get_controller_angular_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		int controller_id = api->godot_variant_as_int(p_args[0]) - 1;
+		const ovrmobile::OvrMobileController* pController = ovr_mobile_session->get_ovr_mobile_controller();
+		if (pController != nullptr) {
+			const ovrmobile::OvrMobileController::ControllerState* pState = pController->get_controller_state(controller_id);
+			if (pState != nullptr && pState->connected) {
+				ovrVector3f v = pState->tracking_state.HeadPose.AngularVelocity;
+				godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+				godot_vector3 gd_vector;
+				api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+				api->godot_variant_new_vector3(&ret, &gd_vector);
+			}
+		}
+	)
+}
+
+GDCALLINGCONV godot_variant get_controller_linear_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		int controller_id = api->godot_variant_as_int(p_args[0]) - 1;
+		const ovrmobile::OvrMobileController* pController = ovr_mobile_session->get_ovr_mobile_controller();
+		if (pController != nullptr) {
+			const ovrmobile::OvrMobileController::ControllerState* pState = pController->get_controller_state(controller_id);
+			if (pState != nullptr && pState->connected) {
+				ovrVector3f v = pState->tracking_state.HeadPose.LinearVelocity;
+				godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+				godot_vector3 gd_vector;
+				api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+				api->godot_variant_new_vector3(&ret, &gd_vector);
+			}
+		}
+	)
+}
+
+GDCALLINGCONV godot_variant get_controller_angular_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		int controller_id = api->godot_variant_as_int(p_args[0]) - 1;
+		const ovrmobile::OvrMobileController* pController = ovr_mobile_session->get_ovr_mobile_controller();
+		if (pController != nullptr) {
+			const ovrmobile::OvrMobileController::ControllerState* pState = pController->get_controller_state(controller_id);
+			if (pState != nullptr && pState->connected) {
+				ovrVector3f v = pState->tracking_state.HeadPose.AngularAcceleration;
+				godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+				godot_vector3 gd_vector;
+				api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+				api->godot_variant_new_vector3(&ret, &gd_vector);
+			}
+		}
+	)
+}
+
+GDCALLINGCONV godot_variant get_controller_linear_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		int controller_id = api->godot_variant_as_int(p_args[0]) - 1;
+		const ovrmobile::OvrMobileController* pController = ovr_mobile_session->get_ovr_mobile_controller();
+		if (pController != nullptr) {
+			const ovrmobile::OvrMobileController::ControllerState* pState = pController->get_controller_state(controller_id);
+			if (pState != nullptr && pState->connected) {
+				ovrVector3f v = pState->tracking_state.HeadPose.LinearAcceleration;
+				godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+				godot_vector3 gd_vector;
+				api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+				api->godot_variant_new_vector3(&ret, &gd_vector);
+			}
+		}
+	)
+}
+
+
+GDCALLINGCONV godot_variant get_head_angular_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+        ovrTracking2 head_tracker = ovr_mobile_session->get_head_tracker();
+		ovrVector3f v = head_tracker.HeadPose.AngularVelocity;
+		godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+		godot_vector3 gd_vector;
+		api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+		api->godot_variant_new_vector3(&ret, &gd_vector);
+	)
+}
+
+GDCALLINGCONV godot_variant get_head_angular_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+        ovrTracking2 head_tracker = ovr_mobile_session->get_head_tracker();
+		ovrVector3f v = head_tracker.HeadPose.AngularAcceleration;
+		godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+		godot_vector3 gd_vector;
+		api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+		api->godot_variant_new_vector3(&ret, &gd_vector);
+	)
+}
+
+GDCALLINGCONV godot_variant get_head_linear_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+        ovrTracking2 head_tracker = ovr_mobile_session->get_head_tracker();
+		ovrVector3f v = head_tracker.HeadPose.LinearVelocity;
+		godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+		godot_vector3 gd_vector;
+		api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+		api->godot_variant_new_vector3(&ret, &gd_vector);
+	)
+}
+
+GDCALLINGCONV godot_variant get_head_linear_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+        ovrTracking2 head_tracker = ovr_mobile_session->get_head_tracker();
+		ovrVector3f v = head_tracker.HeadPose.LinearAcceleration;
+		godot_real world_scale = arvr_api->godot_arvr_get_worldscale();
+		godot_vector3 gd_vector;
+		api->godot_vector3_new(&gd_vector, v.x * world_scale, v.y * world_scale, v.z * world_scale);
+		api->godot_variant_new_vector3(&ret, &gd_vector);
 	)
 }

--- a/src/config/ovr_utilities.h
+++ b/src/config/ovr_utilities.h
@@ -22,6 +22,16 @@ GDCALLINGCONV godot_variant get_ipd(godot_object *p_instance, void *p_method_dat
 // Expects a Color parameter in GDScript and sets the color multiplier for the default layer used by the VrAPI compositor
 GDCALLINGCONV godot_variant set_default_layer_color_scale(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 
+GDCALLINGCONV godot_variant get_controller_angular_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant get_controller_linear_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant get_controller_angular_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant get_controller_linear_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+GDCALLINGCONV godot_variant get_head_angular_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant get_head_linear_velocity(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant get_head_angular_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+GDCALLINGCONV godot_variant get_head_linear_acceleration(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
 
 #ifdef __cplusplus
 }

--- a/src/ovr_mobile_controller.cpp
+++ b/src/ovr_mobile_controller.cpp
@@ -38,7 +38,7 @@ void OvrMobileController::process(ovrMobile *ovr, ovrJava *java, double predicte
 }
 
 void OvrMobileController::update_controller_vibration(ovrMobile *ovr,
-		ControllerState controller_state) {
+		ControllerState& controller_state) {
 	if (!controller_state.connected || controller_state.godot_controller_id == kInvalidGodotControllerId) {
 		return;
 	}
@@ -53,7 +53,7 @@ void OvrMobileController::update_controller_vibration(ovrMobile *ovr,
 }
 
 void OvrMobileController::update_controller_input_state(ovrMobile *ovr,
-		ControllerState controller_state) {
+		ControllerState& controller_state) {
 	if (!controller_state.connected || controller_state.godot_controller_id == kInvalidGodotControllerId) {
 		return;
 	}
@@ -137,20 +137,19 @@ void OvrMobileController::update_controller_input_state(ovrMobile *ovr,
 }
 
 void OvrMobileController::update_controller_tracking_state(ovrMobile *ovr,
-		ControllerState controller_state, double predicted_display_time) {
+		ControllerState& controller_state, double predicted_display_time) {
 	if (!controller_state.connected || controller_state.godot_controller_id == kInvalidGodotControllerId) {
 		return;
 	}
 
 	// Tracked remote is connected. Get the device tracking state.
-	ovrTracking tracking_state;
-	if (vrapi_GetInputTrackingState(ovr, controller_state.remote_capabilities.Header.DeviceID, predicted_display_time, &tracking_state) < 0) {
+	if (vrapi_GetInputTrackingState(ovr, controller_state.remote_capabilities.Header.DeviceID, predicted_display_time, &controller_state.tracking_state) < 0) {
 		return;
 	}
 
 	// Update the controller transform.
 	godot_transform transform;
-	godot_transform_from_ovr_pose(&transform, tracking_state.HeadPose.Pose, arvr_api->godot_arvr_get_worldscale());
+	godot_transform_from_ovr_pose(&transform, controller_state.tracking_state.HeadPose.Pose, arvr_api->godot_arvr_get_worldscale());
 	arvr_api->godot_arvr_set_controller_transform(controller_state.godot_controller_id, &transform,
 			has_orientation_tracking(controller_state.remote_capabilities),
 			has_position_tracking(controller_state.remote_capabilities));

--- a/src/ovr_mobile_controller.h
+++ b/src/ovr_mobile_controller.h
@@ -14,23 +14,29 @@ namespace ovrmobile {
 
 class OvrMobileController {
 public:
+	struct ControllerState {
+		bool connected = false;
+		int godot_controller_id = 0;
+		ovrInputTrackedRemoteCapabilities remote_capabilities;
+		ovrTracking tracking_state;
+	};
+
 	OvrMobileController();
 
 	~OvrMobileController();
 
 	void process(ovrMobile *ovr, ovrJava *java, double predicted_display_time);
 
+	const ControllerState* get_controller_state(int hand_index) const {
+		if (hand_index < 0 || hand_index >= MAX_HANDS) return nullptr;
+		return &controllers[hand_index];
+	}
+
 private:
 	enum ControllerHand {
 		LEFT_HAND,
 		RIGHT_HAND,
 		MAX_HANDS
-	};
-
-	struct ControllerState {
-		bool connected = false;
-		int godot_controller_id = 0;
-		ovrInputTrackedRemoteCapabilities remote_capabilities;
 	};
 
 	inline bool has_analog_grip_trigger(const ovrInputTrackedRemoteCapabilities &capabilities) const {
@@ -97,11 +103,11 @@ private:
 
 	void update_controllers_connection_state(ovrMobile *ovr, ovrJava *java);
 
-	void update_controller_tracking_state(ovrMobile *ovr, ControllerState controller_state, double predicted_display_time);
+	void update_controller_tracking_state(ovrMobile *ovr, ControllerState& controller_state, double predicted_display_time);
 
-	void update_controller_input_state(ovrMobile *ovr, ControllerState controller_state);
+	void update_controller_input_state(ovrMobile *ovr, ControllerState& controller_state);
 
-	void update_controller_vibration(ovrMobile *ovr, ControllerState controller_state);
+	void update_controller_vibration(ovrMobile *ovr, ControllerState& controller_state);
 
 	ControllerState controllers[MAX_HANDS];
 };

--- a/src/ovr_mobile_session.h
+++ b/src/ovr_mobile_session.h
@@ -70,6 +70,8 @@ public:
 
 	ovrTracking2 get_head_tracker() {return head_tracker;};
 
+	const OvrMobileController* get_ovr_mobile_controller() const {return ovr_mobile_controller;};
+
 	const ovrJava *get_ovr_java() {
 		return &java;
 	}


### PR DESCRIPTION
Hi,

me again with another API extension proposal :-)
There was a short discussion yesterday on discord if there is an elegant method to get the controller velocities. So far I used the averaging method from the godot vr starter tutorial. But this is rather unprecise. The VrApi already has this information available and it is queried each frame.

This proposal extends the OvrUtilities.gdns API to allow accessing the acceleration and velocity information for the controllers and the head that was predicted for the next display frame. 
In gdscript access will look then like this:
```
ovrUtilities.get_controller_angular_acceleration(controller_id)
ovrUtilities.get_head_linear_velocity()
```

To achieve this I extended the `struct ControllerState` from ovr_mobile_controller.h to also contain and remember the pose information.

I tried to match a bit the API to what I understood from the last comments. That is why I made 4 separate functions for linear/angular velocity/acceleration instead of returning everything together in an array for example. Let me know what you think and if it would be a good addition to the godot_oculus_mobile API.