### PR TITLE
Add dynamic foveation enable to ovr_performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ func do_something():
   print(ovrUtilities.get_head_linear_acceleration());
 ```
 
+Performance settings are in the OvrPerformance GDNative script class:
+```
+onready var ovrPerformance = preload("res://addons/godot_ovrmobile/OvrPerformance.gdns").new()
+
+func change_performance_settings():
+    # enable the extra latency mode: this gives some performance headroom at the cost
+    # of one more frame of latency
+  	ovrPerformance.set_extra_latency_mode(1); 
+		
+    # set fixed foveation level
+    # for details see https://developer.oculus.com/documentation/quest/latest/concepts/mobile-ffr/
+		ovrPerformance.set_foveation_level(4); 
+
+    # if you want dynamic foveation make sure to set the maximum desired foveation with the previous function
+    # before you enable dynamic foveation
+		ovrPerformance.set_enable_dynamic_foveation(true);
+```
+
 Hand Tracking (experimental)
 ------------
 The hand tracking API is still in a very early state and might change in future updates. It is contained in `OvrHandTracking.gdns`. To see an example

--- a/src/config/ovr_performance.cpp
+++ b/src/config/ovr_performance.cpp
@@ -28,6 +28,9 @@ void register_gdnative_performance(void *handle) {
     method.method = &set_foveation_level;
     nativescript_api->godot_nativescript_register_method(handle, kClassName, "set_foveation_level", attributes, method);
 
+	method.method = &set_enable_dynamic_foveation;
+    nativescript_api->godot_nativescript_register_method(handle, kClassName, "set_enable_dynamic_foveation", attributes, method);
+
     method.method = &set_swap_interval;
     nativescript_api->godot_nativescript_register_method(handle, kClassName, "set_swap_interval", attributes, method);
 }
@@ -93,6 +96,32 @@ GDCALLINGCONV godot_variant set_foveation_level(godot_object *, void *, void *p_
                 api->godot_variant_new_bool(&ret, foveation_valid);
 			}
 
+	)
+}
+
+GDCALLINGCONV godot_variant set_enable_dynamic_foveation(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args) {
+	CHECK_OVR(
+		if (p_num_args != 1) {
+			ALOGW("set_enable_dynamic_foveation(enabled) requires 1 parameter; got %d", p_num_args);
+		} else {
+			// Check if foveation is available.
+			int foveation_available = vrapi_GetSystemPropertyInt(ovr_java, VRAPI_SYS_PROP_FOVEATION_AVAILABLE);
+			if (foveation_available == VRAPI_TRUE) {
+				// Retrieve if set enable or disable
+				bool enable_dynamic_foveation = api->godot_variant_as_bool(p_args[0]);
+				bool dynamic_foveation_valid = false;
+				if (ovrmobile::is_oculus_go_device(ovr_java)) {
+					dynamic_foveation_valid = false;
+				} else if (ovrmobile::is_oculus_quest_device(ovr_java)) {
+					dynamic_foveation_valid = true;
+				}
+
+				if (dynamic_foveation_valid) {
+					vrapi_SetPropertyInt(ovr_java, VRAPI_DYNAMIC_FOVEATION_ENABLED, enable_dynamic_foveation);
+				}
+				api->godot_variant_new_bool(&ret, dynamic_foveation_valid);
+			}
+		}
 	)
 }
 

--- a/src/config/ovr_performance.h
+++ b/src/config/ovr_performance.h
@@ -35,6 +35,11 @@ GDCALLINGCONV godot_variant set_extra_latency_mode(godot_object *p_instance, voi
 // - Oculus Go: https://developer.oculus.com/documentation/mobilesdk/latest/concepts/mobile-ffr/
 GDCALLINGCONV godot_variant set_foveation_level(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
 
+// Enables or disables dynamic foveation
+// Returns true if it's available 
+GDCALLINGCONV godot_variant set_enable_dynamic_foveation(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
+
+
 // Sets the swap interval to control the application frame timing.
 // See https://developer.oculus.com/documentation/mobilesdk/latest/concepts/mobile-vrapi#frame-timing for additional background.
 GDCALLINGCONV godot_variant set_swap_interval(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);


### PR DESCRIPTION
This PR adds a helper function in the ovr_performance gdns class to enable or disable dynamic foveated rendering as described in https://github.com/GodotVR/godot_oculus_mobile/issues/79.
Let me know if sth. should be changed.

Here are some test shots where the foveation level changes:

![dyn_fov_shot01](https://user-images.githubusercontent.com/1610621/71925292-03ae6080-3191-11ea-9817-aedf19a41b6b.jpg)
![dyn_fov_shot02](https://user-images.githubusercontent.com/1610621/71925299-07da7e00-3191-11ea-973a-7702a4742e5d.jpg)
![dyn_fov_shot03](https://user-images.githubusercontent.com/1610621/71925316-0d37c880-3191-11ea-8fbb-164ab996ebec.jpg)
