### PR TITLE
Fixing worldscale for controllers

### DIFF
--- a/demo/addons/godot_ovrmobile/example_scenes/ARVROriginWithInitAndMovement.gd
+++ b/demo/addons/godot_ovrmobile/example_scenes/ARVROriginWithInitAndMovement.gd
@@ -30,6 +30,8 @@ var controllers_vibration_duration = {}
 # some of the Oculus VrAPI constants are defined in this file. Have a look into it to learn more
 var ovrVrApiTypes = load("res://addons/godot_ovrmobile/OvrVrApiTypes.gd").new();
 
+# react to the worldscale changing
+var was_world_scale = 1.0
 
 func _ready():
 	_initialize_ovr_mobile_arvr_interface();
@@ -38,6 +40,7 @@ func _ready():
 func _process(delta_t):
 	_check_and_perform_runtime_config()
 	_check_move(delta_t)
+	_check_worldscale()
 	_update_controllers_vibration(delta_t)
 
 
@@ -268,3 +271,11 @@ func _on_RightTouchController_button_release(button):
 	if (ovr_utilities):
 		# reset the color to neutral again
 		ovr_utilities.set_default_layer_color_scale(Color(1.0, 1.0, 1.0, 1.0));
+
+func _check_worldscale():
+	if was_world_scale != world_scale:
+		was_world_scale = world_scale
+		var inv_world_scale = 1.0 / was_world_scale
+		var controller_scale = Vector3(inv_world_scale, inv_world_scale, inv_world_scale)
+		$"LeftTouchController/left-controller".scale = controller_scale
+		$"RightTouchController/right-controller".scale = -controller_scale

--- a/plugin/src/main/cpp/ovr_mobile_controller.cpp
+++ b/plugin/src/main/cpp/ovr_mobile_controller.cpp
@@ -218,7 +218,7 @@ void OvrMobileController::update_controller_tracking_state_tracked_remote(ovrMob
 
 	// Update the controller transform.
 	godot_transform transform;
-	godot_transform_from_ovr_pose(&transform, controller_state.tracking_state.HeadPose.Pose, godot::arvr_api->godot_arvr_get_worldscale());
+	godot_transform_from_ovr_pose(&transform, controller_state.tracking_state.HeadPose.Pose, 1.0); // worldscale is already applied in godot_arvr_set_controller_transform
 	godot::arvr_api->godot_arvr_set_controller_transform(controller_state.godot_controller_id, &transform,
 			has_orientation_tracking(controller_state.remote_capabilities),
 			has_position_tracking(controller_state.remote_capabilities) || is_oculus_go_controller(controller_state.remote_capabilities));
@@ -236,7 +236,7 @@ void OvrMobileController::update_controller_tracking_state_hand(ovrMobile *ovr, 
 	// Update the controller transform.
 	godot_transform transform;
 	//godot_transform_from_ovr_pose(&transform, controller_state.tracking_state.HeadPose.Pose, godot::arvr_api->godot_arvr_get_worldscale());
-	godot_transform_from_ovr_pose(&transform, controller_state.hand_pose.RootPose, godot::arvr_api->godot_arvr_get_worldscale());
+	godot_transform_from_ovr_pose(&transform, controller_state.hand_pose.RootPose, 1.0); // worldscale is already applied in godot_arvr_set_controller_transform
 	godot::arvr_api->godot_arvr_set_controller_transform(controller_state.godot_controller_id, &transform, true, true);
 }
 


### PR DESCRIPTION
Changing scale of controllers based on worldscale and removing the double applying of worldscale to the tracking.

Haven't looked at hand tracking yet and still downloading SDK so I can test (had to reinstall my PC few weeks back, bah)

fixes #103 