### PR TITLE
Fix the controller vibration API

### DIFF
--- a/demo/addons/godot_ovrmobile/example_scenes/ARVROriginWithHandTracking.gd
+++ b/demo/addons/godot_ovrmobile/example_scenes/ARVROriginWithHandTracking.gd
@@ -143,7 +143,7 @@ func _initialize_ovr_mobile_arvr_interface():
 			if (ovr_utilities): ovr_utilities = ovr_utilities.new()
 			if (ovr_hand_tracking): ovr_hand_tracking = ovr_hand_tracking.new()
 			if (ovr_vr_api_proxy): ovr_vr_api_proxy = ovr_vr_api_proxy.new()
-			
+
 			# Connect to the plugin signals
 			_connect_to_signals()
 

--- a/plugin/src/main/cpp/api/ovr_input.cpp
+++ b/plugin/src/main/cpp/api/ovr_input.cpp
@@ -2,21 +2,18 @@
 #include "api_common.h"
 
 namespace ovrmobile {
-    bool vibrate_controller(OvrMobileSession *session, int controller_id, float intensity) {
-        return check_session_initialized<bool>(session, [&]() {
-            bool result = false;
-            const OvrMobileController *controller = session->get_ovr_mobile_controller();
-            if (controller) {
-                const OvrMobileController::ControllerState *state = controller->get_controller_state_by_id(
-                        controller_id);
-                if (state &&
-                    OvrMobileController::supports_haptic_vibration(state->remote_capabilities)) {
-                    result = vrapi_SetHapticVibrationSimple(session->get_ovr_mobile_context(),
-                                                            state->remote_capabilities.Header.DeviceID,
-                                                            intensity) == ovrSuccess;
-                }
-            }
-            return result;
-        }, []() { return false; });
-    }
+bool vibrate_controller(OvrMobileSession* session,
+                        int controller_id,
+                        int duration_in_ms,
+                        float intensity) {
+    return check_session_initialized<bool>(session, [&]() {
+      bool result = false;
+      OvrMobileController* controller = session->get_ovr_mobile_controller();
+      if (controller) {
+          controller->vibrate_controller(controller_id, duration_in_ms, intensity);
+          result = true;
+      }
+      return result;
+    }, []() { return false; });
+}
 } // namespace ovrmobile

--- a/plugin/src/main/cpp/api/ovr_input.h
+++ b/plugin/src/main/cpp/api/ovr_input.h
@@ -6,7 +6,10 @@
 namespace ovrmobile {
 // Vibrate the controller matching the given controller ID.
 // Returns true if the controller was vibrated, false otherwise.
-bool vibrate_controller(OvrMobileSession *session, int controller_id, float intensity);
+bool vibrate_controller(OvrMobileSession* session,
+                        int controller_id,
+                        int duration_in_ms,
+                        float intensity);
 } // namespace ovrmobile
 
 #endif // OVR_INPUT_H

--- a/plugin/src/main/cpp/common.h
+++ b/plugin/src/main/cpp/common.h
@@ -76,6 +76,10 @@ inline bool check_bit(uint32_t in, uint32_t bits) {
 	return (in & bits) != 0;
 }
 
+inline double get_time_in_ms() {
+    return vrapi_GetTimeInSeconds() * 1000;
+}
+
 void godot_transform_from_ovrMatrix(godot_transform *p_dest, const ovrMatrix4f *p_matrix, godot_real p_world_scale);
 
 void godot_transform_from_ovr_pose(godot_transform *dest, const ovrPosef &pose, const float world_scale);

--- a/plugin/src/main/cpp/gdnative/godot_ovrmobile.cpp
+++ b/plugin/src/main/cpp/gdnative/godot_ovrmobile.cpp
@@ -17,6 +17,7 @@
 #include "gdnative/nativescript/ovr_tracking_transform_ns.h"
 #include "gdnative/nativescript/ovr_utilities_ns.h"
 #include "gdnative/nativescript/ovr_hand_tracking_ns.h"
+#include "gdnative/nativescript/ovr_input_ns.h"
 
 // experimental low-level VrApi access
 #include "gdnative/nativescript/ovr_vr_api_proxy_ns.h"
@@ -42,6 +43,7 @@ void GDN_EXPORT godot_ovrmobile_nativescript_init(void *handle) {
 	register_gdnative_utilities(handle);
 	register_gdnative_hand_tracking(handle);
 	register_gdnative_vr_api_proxy(handle);
+	register_gdnative_input(handle);
 }
 
 void GDN_EXPORT godot_ovrmobile_nativescript_terminate(void *handle) {

--- a/plugin/src/main/cpp/gdnative/nativescript/ovr_input_ns.cpp
+++ b/plugin/src/main/cpp/gdnative/nativescript/ovr_input_ns.cpp
@@ -16,9 +16,6 @@ void register_gdnative_input(void *handle) {
 	// register all the functions that we want to expose via the OvrInput class in GDScript
 	godot_instance_method method = { NULL, NULL, NULL };
 	godot_method_attributes attributes = { GODOT_METHOD_RPC_MODE_DISABLED };
-
-	method.method = &vibrate_controller;
-	godot::nativescript_api->godot_nativescript_register_method(handle, kClassName, "vibrate_controller", attributes, method);
 }
 
 GDCALLINGCONV void *ovr_input_constructor(godot_object *instance, void *method_data) {
@@ -29,13 +26,4 @@ GDCALLINGCONV void ovr_input_destructor(godot_object *instance, void *method_dat
 	if (user_data) {
 		reset_ovr_config_data_struct(static_cast<ovr_config_data_struct *>(user_data));
 	}
-}
-
-GDCALLINGCONV godot_variant vibrate_controller(godot_object *instance, void *method_data, void *p_user_data, int num_args, godot_variant **args) {
-	CHECK_USER_DATA(
-			const int controller_id = godot::api->godot_variant_as_int(args[0]);
-			const double intensity = godot::api->godot_variant_as_real(args[1]);
-			godot::api->godot_variant_new_bool(&ret, ovrmobile::vibrate_controller(ovr_mobile_session, controller_id, intensity));
-
-	)
 }

--- a/plugin/src/main/cpp/gdnative/nativescript/ovr_input_ns.h
+++ b/plugin/src/main/cpp/gdnative/nativescript/ovr_input_ns.h
@@ -13,8 +13,6 @@ extern "C" {
   GDCALLINGCONV void *ovr_input_constructor(godot_object *instance, void *method_data);
   GDCALLINGCONV void ovr_input_destructor(godot_object *instance, void *method_data, void *user_data);
 
-  GDCALLINGCONV godot_variant vibrate_controller(godot_object *instance, void *method_data, void *p_user_data, int num_args, godot_variant **args);
-
 #ifdef __cplusplus
 };
 #endif

--- a/plugin/src/main/cpp/jni/ovr_input_jni.cpp
+++ b/plugin/src/main/cpp/jni/ovr_input_jni.cpp
@@ -15,9 +15,13 @@
 extern "C" {
 
 JNIEXPORT void JNICALL
-JNI_METHOD(nativeVibrateController)(JNIEnv *env, jclass clazz, jint controller_id,
-                                    jfloat intensity) {
-    ovrmobile::vibrate_controller(get_session(), controller_id, intensity);
+JNI_METHOD(vibrateController)(JNIEnv* env,
+                              jclass,
+                              jobject,
+                              jint controller_id,
+                              jint duration_in_ms,
+                              jfloat intensity) {
+    ovrmobile::vibrate_controller(get_session(), controller_id, duration_in_ms, intensity);
 }
 
 };

--- a/plugin/src/main/cpp/ovr_mobile_controller.cpp
+++ b/plugin/src/main/cpp/ovr_mobile_controller.cpp
@@ -1,5 +1,5 @@
 /**
-* Created by Fredia Huya-Kouadio. 
+* Created by Fredia Huya-Kouadio.
 */
 
 #include "ovr_mobile_controller.h"
@@ -15,8 +15,6 @@ const int kAnalogGripTriggerAxis = 3;
 const float kIndexTriggerPressedThreshold = 0.6f;
 const float kGripTriggerPressedThreshold = 0.6f;
 
-const int kInvalidGodotControllerId = 0;
-
 const char *kUnsupportedController = "Unsupported Controller";
 const char *kGearVRController = "Gear VR Controller";
 const char *kOculusGoController = "Oculus Go Controller";
@@ -24,6 +22,11 @@ const char *kOculusTouchLeftController = "Oculus Touch Left Controller";
 const char *kOculusTouchRightController = "Oculus Touch Right Controller";
 const char *kOculusTrackedLeftHand = "Oculus Tracked Left Hand";
 const char *kOculusTrackedRightHand = "Oculus Tracked Right Hand";
+
+// We set the duration for the controller rumble to 1 ms so it's only active for one frame.
+const int kControllerRumbleDurationInMs = 1;
+
+const double kEspilonTimeInMs = 5;
 
 } // namespace
 
@@ -45,17 +48,41 @@ void OvrMobileController::update_controller_vibration(ovrMobile *ovr, Controller
 		return;
 	}
 
-	if (controller_state.capability_header.Type == ovrControllerType_TrackedRemote) {
-		if (!supports_haptic_vibration(controller_state.remote_capabilities)) {
-			return;
-		}
+    if (!(controller_state.capability_header.Type == ovrControllerType_TrackedRemote)
+        || !supports_haptic_vibration(controller_state.remote_capabilities)) {
+        // unsupported controller
+        return;
+    }
 
-		// Get the vibration intensity.
-		const float vibration = godot::arvr_api->godot_arvr_get_controller_rumble(controller_state.godot_controller_id);
-		vrapi_SetHapticVibrationSimple(ovr, controller_state.remote_capabilities.Header.DeviceID, vibration);
-	} else {
-		// unsupprted controller
-	}
+    // Get the controller rumble intensity. This will override previous controller vibration
+    // requests as this takes precedence.
+    const float intensity = godot::arvr_api->godot_arvr_get_controller_rumble(controller_state.godot_controller_id);
+	vibrate_controller(controller_state.godot_controller_id, kControllerRumbleDurationInMs, intensity);
+
+    // Process controller vibrations.
+    ControllerVibration& vibration = controllers_vibrations[controller_state.godot_controller_id];
+    double current_time_in_ms = get_time_in_ms();
+    if (vibration.is_vibrating
+        && (vibration.end_time_in_ms < (current_time_in_ms + kEspilonTimeInMs))) {
+        // Stop vibrating
+        vrapi_SetHapticVibrationSimple(ovr,
+                                       controller_state.remote_capabilities.Header.DeviceID,
+                                       0.0f);
+
+        // Reset the vibration parameters
+        vibration.end_time_in_ms = 0;
+        vibration.is_vibrating = false;
+        vibration.intensity = 0;
+        controllers_vibrations.erase(controller_state.godot_controller_id);
+    }
+
+    if (vibration.end_time_in_ms > 0) {
+        vrapi_SetHapticVibrationSimple(ovr,
+                                       controller_state.remote_capabilities.Header.DeviceID,
+                                       vibration.intensity);
+
+        vibration.is_vibrating = true;
+    }
 }
 
 void OvrMobileController::update_controller_input_state(ovrMobile *ovr,ControllerState& controller_state) {
@@ -214,9 +241,10 @@ void OvrMobileController::update_controller_tracking_state_hand(ovrMobile *ovr, 
 
 
 void OvrMobileController::update_controllers_connection_state(ovrMobile *ovr, ovrJava *java) {
-	// Reset the controllers connected state.
+	// Reset the controllers connected and active state.
 	for (auto &controller : controllers) {
 		controller.connected = false;
+		controller.primary = false;
 	}
 
 	// Check controller(s) connection state.
@@ -237,7 +265,7 @@ void OvrMobileController::update_controllers_connection_state(ovrMobile *ovr, ov
 				// We're handling a Gear VR or Oculus Go controller. Let's query the user dominant hand to find out where to
 				// assign the controller.
 				auto dominant_hand = static_cast<ovrHandedness>(vrapi_GetSystemPropertyInt(java, VRAPI_SYS_PROP_DOMINANT_HAND));
-				handedness = get_controller_handedness(dominant_hand);
+				handedness = dominant_hand == VRAPI_HAND_LEFT ? LEFT_HAND : RIGHT_HAND;
 			}
 
 			// this check forces a reconnect below because the type of the controller changed
@@ -257,7 +285,7 @@ void OvrMobileController::update_controllers_connection_state(ovrMobile *ovr, ov
 			}
 
 			ControllerHand handedness = get_controller_handedness(tracked_hand_capabilities);
-			
+
 			// this check forces a reconnect below because the type of the controller changed
 			if (controllers[handedness].capability_header.Type != ovrControllerType_Hand && controllers[handedness].godot_controller_id != kInvalidGodotControllerId) {
 				godot::arvr_api->godot_arvr_remove_controller(controllers[handedness].godot_controller_id);
@@ -271,24 +299,38 @@ void OvrMobileController::update_controllers_connection_state(ovrMobile *ovr, ov
 		}
 	}
 
-	// Notify Godot of the updated connection states.
+	// Get the active input device id.
+	int active_input_device_id = -1;
+	vrapi_GetPropertyInt(java, VRAPI_ACTIVE_INPUT_DEVICE_ID, &active_input_device_id);
+
 	for (int hand = 0; hand < MAX_HANDS; hand++) {
 		ControllerState *controller = &controllers[hand];
 
-		if (controller->connected && controller->godot_controller_id == kInvalidGodotControllerId) {
-			// Register the controller with Godot.
-			if (controller->capability_header.Type == ovrControllerType_TrackedRemote) {
-				controller->godot_controller_id = godot::arvr_api->godot_arvr_add_controller(
-						const_cast<char *>(get_controller_model_name(*controller)), get_godot_hand(static_cast<ControllerHand>(hand)),
-						has_orientation_tracking(controller->remote_capabilities),
-						has_position_tracking(controller->remote_capabilities));
-			} else if (controller->capability_header.Type == ovrControllerType_Hand) {
-				controller->godot_controller_id = godot::arvr_api->godot_arvr_add_controller(
-						const_cast<char *>(get_controller_model_name(*controller)), get_godot_hand(static_cast<ControllerHand>(hand)),
-						true, true);
-			}
-			ALOGV("Updated Controller '%s' (Godot id %d; Oculus id %d)", get_controller_model_name(*controller), controller->godot_controller_id, hand);
-		} else if (!controller->connected && controller->godot_controller_id != kInvalidGodotControllerId) {
+		// Notify Godot of the updated connection states.
+		if (controller->connected) {
+		    controller->primary = controller->capability_header.DeviceID == active_input_device_id;
+
+            if (controller->godot_controller_id == kInvalidGodotControllerId) {
+                // Register the controller with Godot.
+                if (controller->capability_header.Type == ovrControllerType_TrackedRemote) {
+                    controller->godot_controller_id = godot::arvr_api->godot_arvr_add_controller(
+                        const_cast<char*>(get_controller_model_name(*controller)),
+                        get_godot_hand(static_cast<ControllerHand>(hand)),
+                        has_orientation_tracking(controller->remote_capabilities),
+                        has_position_tracking(controller->remote_capabilities));
+                } else if (controller->capability_header.Type == ovrControllerType_Hand) {
+                    controller->godot_controller_id = godot::arvr_api->godot_arvr_add_controller(
+                        const_cast<char*>(get_controller_model_name(*controller)),
+                        get_godot_hand(static_cast<ControllerHand>(hand)),
+                        true,
+                        true);
+                }
+                ALOGV("Updated Controller '%s' (Godot id %d; Oculus id %d)",
+                      get_controller_model_name(*controller),
+                      controller->godot_controller_id,
+                      hand);
+            }
+        } else if (controller->godot_controller_id != kInvalidGodotControllerId) {
 			// Unregister the controller from Godot.
 			ALOGV("Unregistered Controller '%s' (Godot id %d; Oculus id %d)", get_controller_model_name(*controller), controller->godot_controller_id, hand);
 			godot::arvr_api->godot_arvr_remove_controller(controller->godot_controller_id);

--- a/plugin/src/main/cpp/ovr_mobile_session.h
+++ b/plugin/src/main/cpp/ovr_mobile_session.h
@@ -84,6 +84,10 @@ public:
 
 	const OvrMobileController* get_ovr_mobile_controller() const {return ovr_mobile_controller;};
 
+	OvrMobileController* get_ovr_mobile_controller() {
+	    return ovr_mobile_controller;
+	}
+
 	const ovrJava *get_ovr_java() {
 		return &java;
 	}

--- a/plugin/src/main/java/org/godotengine/plugin/vr/oculus/mobile/api/OvrInput.kt
+++ b/plugin/src/main/java/org/godotengine/plugin/vr/oculus/mobile/api/OvrInput.kt
@@ -7,11 +7,13 @@ package org.godotengine.plugin.vr.oculus.mobile.api
 
 import org.godotengine.plugin.vr.oculus.mobile.OvrMobilePlugin
 
+private const val PRIMARY_CONTROLLER_ID = -1
+
 /**
  * Vibrate the controller at the given intensity.
- * @param controllerId Id of the controller to vibrate
+ * @param controllerId Id of the controller to vibrate. Defaults to the primary controller id.
+ * @param durationInMs Vibration duration in milliseconds
  * @param intensity Vibration intensity
  */
-fun OvrMobilePlugin.vibrateController(controllerId: Int, intensity: Float) = nativeVibrateController(controllerId, intensity)
-
-private external fun nativeVibrateController(controllerId: Int, intensity: Float)
+@JvmOverloads
+external fun OvrMobilePlugin.vibrateController(controllerId: Int = PRIMARY_CONTROLLER_ID, durationInMs: Int, intensity: Float)


### PR DESCRIPTION
The vrapi_SetHapticVibrationSimple(...) method is supposed to be called once per frame.
To comply, the new logic batches the vibration requests (last one wins), and fire the method call once per frame during `_process` if a vibration request for the controller is available.
The API exposed by the plugin is augmented to take a `duration_in_ms` parameter, which the logic uses to keep firing vrapi_SetHapticVibrationSimple(...) calls until the duration has been reached.

The controller demo has been updated to make the touch controllers vibrate when the `A/X` button is pressed.