### PR TITLE
Update OpenXR Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oculus Mobile Godot plugin (DEPRECATED)
 
-DEPRECATED - The [OpenXR plugin](https://docs.godotengine.org/en/stable/tutorials/vr/openxr/index.html#openxr-plugin) is the recommended option.
+DEPRECATED - The [OpenXR plugin]([https://docs.godotengine.org/en/stable/tutorials/xr/setting_up_xr.html#openxr](https://docs.godotengine.org/en/stable/tutorials/xr/setting_up_xr.html#openxr)) is the recommended option.
 
 ## About
 This repository contains the source code for the Godot Oculus Mobile plugin.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oculus Mobile Godot plugin (DEPRECATED)
 
-DEPRECATED - The [OpenXR plugin]([https://docs.godotengine.org/en/stable/tutorials/xr/setting_up_xr.html#openxr](https://docs.godotengine.org/en/stable/tutorials/xr/setting_up_xr.html#openxr)) is the recommended option.
+DEPRECATED - The [OpenXR plugin](https://docs.godotengine.org/en/stable/tutorials/xr/setting_up_xr.html#openxr) is the recommended option.
 
 ## About
 This repository contains the source code for the Godot Oculus Mobile plugin.


### PR DESCRIPTION
This will redirect people to the updated page for the new OpenXR plugin. Also, could we archive this repo so it is more obvious that it is deprecated without reading the readme? 